### PR TITLE
Fixed a RegExp and Ruby warning

### DIFF
--- a/lib/creole/parser.rb
+++ b/lib/creole/parser.rb
@@ -252,7 +252,7 @@ module Creole
         else
           @out << escape_html($&)
         end
-      when /\A([:alpha:]|[:digit:])+/
+      when /\A([[:alpha:]]|[[:digit:]])+/
         @out << $&
       when /\A\s+/
         @out << ' ' if @out[-1] != ?\s


### PR DESCRIPTION
Fixed a Regexp, it should be `[[:digit:]]` instead of `[:digit:]`.
