### PR TITLE
add Ruby license metadata to gemspec

### DIFF
--- a/creole.gemspec
+++ b/creole.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = %w(lib)
 
   s.homepage = 'http://github.com/minad/creole'
+  s.license  = 'Ruby'
   
   s.add_development_dependency('bacon')
   s.add_development_dependency('rake')


### PR DESCRIPTION
This pull request allows RubyGems.org and other tools (such as gem2rpm) to report a license for your gem.
