### PR TITLE
Remove lookahead from parse table

### DIFF
--- a/lib/creole/parser.rb
+++ b/lib/creole/parser.rb
@@ -298,7 +298,7 @@ module Creole
 
     def parse_table_row(str)
       @out << '<tr>'
-      str.scan(/\s*\|(=)?\s*((\[\[.*?\]\]|\{\{.*?\}\}|[^|~]|~.)*)(?=\||$)/) do
+      str.scan(/\s*\|(=)?\s*((\[\[.*?\]\]|\{\{.*?\}\}|[^|~]|~.)*)/) do
         if !$2.empty? || !$'.empty?
           @out << ($1 ? '<th>' : '<td>')
           parse_inline($2) if $2

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -454,6 +454,8 @@ describe Creole::Parser do
     tc "<table><tr><th>Header</th></tr></table>", "|=Header|"
 
     tc "<table><tr><td>c1</td><td><a href=\"Link\">Link text</a></td><td><img src=\"Image\" alt=\"Image text\"/></td></tr></table>", "|c1|[[Link|Link text]]|{{Image|Image text}}|"
+    # Excessive backtracing does not occur
+    tc "<table><tr><td><tt>{}</tt><tt>{}</tt><tt>{}</tt><tt>{}</tt><tt>{}</tt><tt>{}</tt><tt>{}</tt>{{{{</td></tr></table>", "|{{{{}}}}{{{{}}}}{{{{}}}}{{{{}}}}{{{{}}}}{{{{}}}}{{{{}}}}{{{{~"
   end
 
   it 'should parse following table' do


### PR DESCRIPTION
This PR removes a lookahead from the `parse_table_row`, as it was extraneous and led to a ReDoS vulnerability. 

Looking ahead to find a `|` is unneeded as the caller function already chops up tables by `|`: [`/\A[ \t]*\|.*$(\r?\n)?/`](https://github.com/minad/creole/blob/15a1b2b46a8ad058668234a8c1b8e05f49df3200/lib/creole/parser.rb#L332-L337), ensuring that we don't need to check for it at this stage as well. 

The ReDoS occurs because the lookahead is reevaluated at each match, causing an exponential matching in the case of a malicious payload like `|{{{{}}}}{{{{}}}}{{{{}}}}{{{{}}}}{{{{}}}}{{{{}}}}{{{{}}}}{{{{~`

If I missed something here, please feel free to close the PR 🙇 

This PR closes https://github.com/larsch/creole/issues/8