### PR TITLE
Explicitly unfreeze mutated string

### DIFF
--- a/lib/creole/parser.rb
+++ b/lib/creole/parser.rb
@@ -71,7 +71,7 @@ module Creole
     #    parser.to_html
     #       #=> "<p><strong>Hello <em>World</em></strong></p>"
     def to_html
-      @out = ''
+      @out = +''
       @p = false
       @stack = []
       parse_block(@text)


### PR DESCRIPTION
Explicitly unfreezing `@out` allows this library to work with `--enable-frozen-string-literal`, and also with future versions of Ruby that may default to frozen string literals (see https://bugs.ruby-lang.org/issues/20205).