### PR TITLE
Replace bacon with rspec

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,8 @@
-task :default => :test
+require 'rspec/core/rake_task'
 
-desc 'Run tests with bacon'
-task :test => FileList['test/*_test.rb'] do |t|
-  sh "bacon -q -Ilib:test #{t.prerequisites.join(' ')}"
+task :default => :spec
+
+desc 'Run tests with rspec'
+RSpec::Core::RakeTask.new(:spec) do |t|
+  t.verbose = true
 end

--- a/creole.gemspec
+++ b/creole.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |s|
   s.homepage = 'http://github.com/minad/creole'
   s.license  = 'Ruby'
   
-  s.add_development_dependency('bacon')
+  s.add_development_dependency('rspec')
   s.add_development_dependency('rake')
 end

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -1,16 +1,14 @@
 require 'creole'
 
-class Bacon::Context
+describe Creole::Parser do
   def tc(html, creole, options = {})
-    Creole.creolize(creole, options).should.equal html
+    expect(Creole.creolize(creole, options)).to eq html
   end
 
   def tce(html, creole)
     tc(html, creole, :extensions => true)
   end
-end
 
-describe Creole::Parser do
   it 'should parse bold' do
     # Creole1.0: Bold can be used inside paragraphs
     tc "<p>This <strong>is</strong> bold</p>", "This **is** bold"


### PR DESCRIPTION
bacon saw its last code change in 2017, and an official [announcement that development "halted"](https://github.com/leahneukirchen/bacon/issues/32). This replaces it with the actively maintained RSpec.

The motivation is https://github.com/Canop/bacon/issues/342, ruby-creole is one of two packages still actively using bacon (the Ruby one).

The change is fair simple, as only the `def tc` helper touches the test runner.