### PR TITLE
Explicitly unfreeze mutated string

### DIFF
--- a/lib/creole/parser.rb
+++ b/lib/creole/parser.rb
@@ -71,7 +71,7 @@ module Creole
     #    parser.to_html
     #       #=> "<p><strong>Hello <em>World</em></strong></p>"
     def to_html
-      @out = ''
+      @out = +''
       @p = false
       @stack = []
       parse_block(@text)


### PR DESCRIPTION
This is a reapplication of the change in #16. The base branch of that PR has a gemspec that is not RubyGems4 compatible. 